### PR TITLE
Day 12 - Add Spinners, Add Multithreading for Content Fetch

### DIFF
--- a/src/bookmarker/cli/main.py
+++ b/src/bookmarker/cli/main.py
@@ -14,6 +14,7 @@ from ..core.exceptions import (
     ArtifactNotFoundError,
     ContentFetchError,
     ContentSummaryError,
+    InvalidContentError,
 )
 from ..core.main import (
     ArtifactTypeEnum,
@@ -135,6 +136,12 @@ def summarize_content(ctx: typer.Context, artifact_id: int):
         )
     except ArtifactNotFoundError:
         config.error_console.print(f"Artifact with ID {artifact_id} not found.")
+        raise typer.Exit(code=1)
+    except InvalidContentError:
+        config.error_console.print(
+            f"Artifact with ID {artifact_id} has no raw content yet.\n"
+            f"Run `bookmarker fetch {artifact_id}` first."
+        )
         raise typer.Exit(code=1)
     except ContentSummaryError:
         config.error_console.print(

--- a/src/bookmarker/cli/main.py
+++ b/src/bookmarker/cli/main.py
@@ -158,16 +158,19 @@ def show_artifact(ctx: typer.Context, artifact_id: int):
     if artifact is None:
         config.error_console.print(f"Artifact with ID {artifact_id} not found.")
         raise typer.Exit(code=1)
-    if artifact.content_raw is None and artifact.content_summary is None:
-        summary = (
-            "Content has not been fetched yet.\n"
-            f"Run `bookmarker fetch {artifact.id}`.\n"
-            f"Then run `bookmarker summarize {artifact.id}`."
-        )
-    elif artifact.content_summary is None:
-        summary = f"No summary yet. Run `bookmarker summarize {artifact.id}`"
+
+    if artifact.content_summary is None:
+        if artifact.content_raw is None:
+            summary = (
+                "Content has not been fetched yet.\n"
+                f"Run `bookmarker fetch {artifact.id}`.\n"
+                f"Then run `bookmarker summarize {artifact.id}`."
+            )
+        else:
+            summary = f"No summary yet. Run `bookmarker summarize {artifact.id}`"
     else:
         summary = escape(artifact.content_summary)
+
     text = Text(summary, justify="left")
     body = Padding(text, (1, 2))
     panel = Panel.fit(

--- a/src/bookmarker/cli/main.py
+++ b/src/bookmarker/cli/main.py
@@ -5,6 +5,7 @@ from rich.console import Console
 from rich.markup import escape
 from rich.padding import Padding
 from rich.panel import Panel
+from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 from rich.text import Text
 
@@ -96,7 +97,13 @@ def fetch_content(ctx: typer.Context, artifact_id: int):
     """Fetches content for the specified artifact ID."""
     config = get_config(ctx)
     try:
-        fetch_and_store_content(config.repo, artifact_id)
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("{task.description}"),
+            transient=True,
+        ) as progress:
+            progress.add_task(description="Fetching...", total=None)
+            fetch_and_store_content(config.repo, artifact_id)
         config.console.print(
             f"[green]Content fetched for artifact ID {artifact_id}.[/]"
         )
@@ -115,8 +122,14 @@ def summarize_content(ctx: typer.Context, artifact_id: int):
     """Fetches content for the specified artifact ID."""
     config = get_config(ctx)
     try:
-        summarizer = get_summarizer()
-        summarize_and_store_content(config.repo, summarizer, artifact_id)
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("{task.description}"),
+            transient=True,
+        ) as progress:
+            progress.add_task(description="Summarizing...", total=None)
+            summarizer = get_summarizer()
+            summarize_and_store_content(config.repo, summarizer, artifact_id)
         config.console.print(
             f"[green]Content summarized for artifact ID {artifact_id}.[/]"
         )


### PR DESCRIPTION
## Change Log
- Add spinners to long-running CLI commands
- Catch InvalidContentError in summarize command
- Add multithreading to fetch-content workflow

## TODO
- [ ] Add tests for multithreading fetch-content
- [ ] Add multithreading to summarize-content
- [ ] Create CLI command to delete artifacts